### PR TITLE
fix call to microtime

### DIFF
--- a/src/Ulid.php
+++ b/src/Ulid.php
@@ -53,7 +53,7 @@ class Ulid
      */
     public static function generate()
     {
-        $now = (int) microtime(true) * 1000;
+        $now = intval(microtime(true) * 1000);
         $duplicateTime = $now === static::$lastGenTime;
 
         $timeChars = '';


### PR DESCRIPTION
the previous incantation would cast the `microtime()` output to `int` before multiplying, which only allowed for 1-second resolution (the last three digits of `$now` were always zero)

casting to `int` after multiplying allows the intended millisecond resolution