### PR TITLE
Add checks to detect invalid characters

### DIFF
--- a/src/Ulid.php
+++ b/src/Ulid.php
@@ -76,27 +76,27 @@ class Ulid
 
         $encodingChars = static::ENCODING_CHARS;
 
-        for ($i = 9; $i >= 0; $i--) {
+        for ($i = static::TIME_LENGTH - 1; $i >= 0; $i--) {
             $mod = $now % static::ENCODING_LENGTH;
             $timeChars = $encodingChars[$mod].$timeChars;
             $now = ($now - $mod) / static::ENCODING_LENGTH;
         }
 
         if (!$duplicateTime) {
-            for ($i = 0; $i < 16; $i++) {
+            for ($i = 0; $i < static::RANDOM_LENGTH; $i++) {
                 static::$lastRandChars[$i] = random_int(0, 31);
             }
         } else {
             // If the timestamp hasn't changed since last push,
             // use the same random number, except incremented by 1.
-            for ($i = 15; $i >= 0 && static::$lastRandChars[$i] === 31; $i--) {
+            for ($i = static::RANDOM_LENGTH - 1; $i >= 0 && static::$lastRandChars[$i] === 31; $i--) {
                 static::$lastRandChars[$i] = 0;
             }
 
             static::$lastRandChars[$i]++;
         }
 
-        for ($i = 0; $i < 16; $i++) {
+        for ($i = 0; $i < static::RANDOM_LENGTH; $i++) {
             $randChars .= $encodingChars[static::$lastRandChars[$i]];
         }
 

--- a/src/Ulid.php
+++ b/src/Ulid.php
@@ -58,7 +58,14 @@ class Ulid
     public static function fromString(string $value, bool $lowercase = false): self
     {
         if (strlen($value) !== static::TIME_LENGTH + static::RANDOM_LENGTH) {
-            throw new InvalidUlidStringException('Invalid ULID string: ' . $value);
+            throw new InvalidUlidStringException('Invalid ULID string (wrong length): ' . $value);
+        }
+
+        // Convert to uppercase for regex. Doesn't matter for output later, that is determined by $lowercase.
+        $value = strtoupper($value);
+
+        if (!preg_match(sprintf('!^[%s]{%d}$!', static::ENCODING_CHARS, static::TIME_LENGTH + static::RANDOM_LENGTH), $value)) {
+            throw new InvalidUlidStringException('Invalid ULID string (wrong characters): ' . $value);
         }
 
         return new static(substr($value, 0, static::TIME_LENGTH), substr($value, static::TIME_LENGTH, static::RANDOM_LENGTH), $lowercase);

--- a/tests/UlidTest.php
+++ b/tests/UlidTest.php
@@ -78,7 +78,7 @@ final class UlidTest extends TestCase
 
     /**
      * @expectedException \Ulid\Exception\InvalidUlidStringException
-     * @expectedExceptionMessage Invalid ULID string:
+     * @expectedExceptionMessage Invalid ULID string (wrong length):
      */
     public function testCreatesFromStringWithInvalidUlid(): void
     {
@@ -87,11 +87,31 @@ final class UlidTest extends TestCase
 
     /**
      * @expectedException \Ulid\Exception\InvalidUlidStringException
-     * @expectedExceptionMessage Invalid ULID string:
+     * @expectedExceptionMessage Invalid ULID string (wrong length):
      */
     public function testCreatesFromStringWithTrailingNewLine(): void
     {
         Ulid::fromString("01AN4Z07BY79KA1307SR9X4MV3\n");
+    }
+
+    public function invalidAlphabetDataProvider(): array
+    {
+        return [
+            'with i' => ['0001eh8yaep8cxp4amwchhdbhi'],
+            'with l' => ['0001eh8yaep8cxp4amwchhdbhl'],
+            'with o' => ['0001eh8yaep8cxp4amwchhdbho'],
+            'with u' => ['0001eh8yaep8cxp4amwchhdbhu'],
+        ];
+    }
+
+    /**
+     * @dataProvider invalidAlphabetDataProvider
+     * @expectedException \Ulid\Exception\InvalidUlidStringException
+     * @expectedExceptionMessage Invalid ULID string (wrong characters):
+     */
+    public function testCreatesFromStringWithInvalidAlphabet($ulid): void
+    {
+        Ulid::fromString($ulid);
     }
 
     public function testConvertsToTimestamp(): void

--- a/tests/UlidTest.php
+++ b/tests/UlidTest.php
@@ -16,7 +16,7 @@ use Ulid\Ulid;
 
 final class UlidTest extends TestCase
 {
-    public function testGeneratesUppercaseIdentiferByDefault(): void
+    public function testGeneratesUppercaseIdentifierByDefault(): void
     {
         $ulid = Ulid::generate();
 
@@ -24,7 +24,7 @@ final class UlidTest extends TestCase
         $this->assertFalse($ulid->isLowercase());
     }
 
-    public function testGeneratesLowercaseIdentiferWhenConfigured(): void
+    public function testGeneratesLowercaseIdentifierWhenConfigured(): void
     {
         $ulid = Ulid::generate(true);
 
@@ -62,9 +62,18 @@ final class UlidTest extends TestCase
         $this->assertSame([(string) $a, (string) $b], $ulids);
     }
 
-    public function testCreatesFromString(): void
+    public function testCreatesFromUppercaseString(): void
     {
         $this->assertEquals('01AN4Z07BY79KA1307SR9X4MV3', (string) Ulid::fromString('01AN4Z07BY79KA1307SR9X4MV3'));
+        $this->assertEquals('01AN4Z07BY79KA1307SR9X4MV3', (string) Ulid::fromString('01AN4Z07BY79KA1307SR9X4MV3', false));
+        $this->assertEquals('01an4z07by79ka1307sr9x4mv3', (string) Ulid::fromString('01AN4Z07BY79KA1307SR9X4MV3', true));
+    }
+
+    public function testCreatesFromLowercaseString(): void
+    {
+        $this->assertEquals('01AN4Z07BY79KA1307SR9X4MV3', (string) Ulid::fromString('01an4z07by79ka1307sr9x4mv3'));
+        $this->assertEquals('01AN4Z07BY79KA1307SR9X4MV3', (string) Ulid::fromString('01an4z07by79ka1307sr9x4mv3', false));
+        $this->assertEquals('01an4z07by79ka1307sr9x4mv3', (string) Ulid::fromString('01an4z07by79ka1307sr9x4mv3', true));
     }
 
     /**


### PR DESCRIPTION
Hey @robinvdvleuten, thanks for the library. Love the ULID concept and was happy to see there was a PHP library.

In my application I found the `Ulid` class accepts invalid Base32 characters (in `Ulid::fromString()`). So I added a check (and test) for that.

It is a three commit PR with some minor other refactors (use of length constants in loop invariants & some more tests), if you disagree with any of them, let me know and I'll leave them out.