### PR TITLE
fix: updates for PHP8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,11 +22,13 @@
         }
     },
     "require": {
-        "php": "^7.1"
+        "php": ">=7.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5",
-        "phpbench/phpbench": "^0.17",
+        "phpunit/phpunit": "^9",
+        "phpbench/phpbench": "^1.0.0-alpha2",
         "symfony/phpunit-bridge": "^5.1"
-    }
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true">
-
-    <testsuites>
-        <testsuite name="Ulid Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Ulid Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <listeners>
+    <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+  </listeners>
 </phpunit>

--- a/tests/UlidTest.php
+++ b/tests/UlidTest.php
@@ -24,7 +24,7 @@ final class UlidTest extends TestCase
     {
         $ulid = Ulid::generate();
 
-        $this->assertRegExp('/[0-9][A-Z]/', (string) $ulid);
+        $this->assertMatchesRegularExpression('/[0-9][A-Z]/', (string) $ulid);
         $this->assertFalse($ulid->isLowercase());
     }
 
@@ -32,7 +32,7 @@ final class UlidTest extends TestCase
     {
         $ulid = Ulid::generate(true);
 
-        $this->assertRegExp('/[0-9][a-z]/', (string) $ulid);
+        $this->assertMatchesRegularExpression('/[0-9][a-z]/', (string) $ulid);
         $this->assertTrue($ulid->isLowercase());
     }
 


### PR DESCRIPTION
Hi Robin

I've made some adjustments for PHP8 compatibility, and fixed some deprecations that arise from upgrading phpunit.

Some things, particularly what I've done with versions in the composer.json might not be the way you want to do it, so I suggest you have a look and see what you think.

Also, my changes aren't compatible with 7.1 and 7.2 - I haven't removed them from the version constraint - it depends whether you want to carry on supporting them or not...

A.