### PR TITLE
Update UlidTest.php

### DIFF
--- a/tests/UlidTest.php
+++ b/tests/UlidTest.php
@@ -58,8 +58,16 @@ final class UlidTest extends TestCase
         $b = Ulid::generate();
 
         $this->assertSame($a->toTimestamp(), $b->toTimestamp());
-        // Only the last character should be different.
-        $this->assertSame(substr($a, 0, -1), substr($b, 0, -1));
+        
+        /*
+         * The `Only the last character should be different.` afirmation is wrong
+         * If generated ulid ends with `YZZ` for instance,
+         * the next would end with `Z00` so all three characters would be different
+         * and because trying to assert all characters except last are the same,
+         * is breaking the tests sometimes
+         */
+        // $this->assertSame(substr($a, 0, -1), substr($b, 0, -1));
+        
         $this->assertNotSame($a->getRandomness(), $b->getRandomness());
     }
 
@@ -195,8 +203,16 @@ final class UlidTest extends TestCase
         $b = Ulid::fromTimestamp(self::VALID_MILLISECONDS);
 
         $this->assertSame($a->getTime(), $b->getTime());
-        // Only the last character should be different.
-        $this->assertSame(substr($a, 0, -1), substr($b, 0, -1));
+
+        /*
+         * The `Only the last character should be different.` afirmation is wrong
+         * If generated ulid ends with `YZZ` for instance,
+         * the next would end with `Z00` so all three characters would be different
+         * and because trying to assert all characters except last are the same,
+         * is breaking the tests sometimes
+         */
+        // $this->assertSame(substr($a, 0, -1), substr($b, 0, -1));
+
         $this->assertNotSame($a->getRandomness(), $b->getRandomness());
     }
 

--- a/tests/UlidTest.php
+++ b/tests/UlidTest.php
@@ -144,4 +144,13 @@ final class UlidTest extends TestCase
         $this->assertEquals(substr($a, 0, -1), substr($b, 0, -1));
         $this->assertNotEquals($a->getRandomness(), $b->getRandomness());
     }
+    
+    public function testCreatesFromTimestampWithInvalidMilliseconds(): void
+    {
+        $this->expectException(InvalidUlidStringException::class);
+        $this->expectExceptionMessage('Invalid ULID string: timestamp too large');
+
+        $ulid = Ulid::fromTimestamp(1000000000000000);
+        $ulid->toTimestamp();
+    }
 }


### PR DESCRIPTION
Refactor of UlidTest.php:

- adding 4 new constants: `VALID_MILLISECONDS`, `INVALID_MILLISECONDS`, `VALID_UPPER_ULID` & `VALID_LOWER_ULID` to be used across multiple tests;
- adding test setup with 2 Ulids, one `generate` and one `fromTimestamp` to be used across multiple tests;
- adding 4 more tests on `invalidAlphabetDataProvider` to cover invalid characters on upper case as well
- broke lines over 80 characters
- changed all `assertEquals` to `assertSame` to check type as well
- Adding missing test for Invalid milliseconds
- Removed wrong assertions that [presumed only the last character would be different](https://github.com/ulid/spec#monotonicity) and were making test fail sometimes